### PR TITLE
Add gpytorch to benchmark Docker images

### DIFF
--- a/cpu-bench/Dockerfile
+++ b/cpu-bench/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update \
 # --break-system-packages is needed because Ubuntu 24.04+ marks system Python as
 # externally managed (PEP 668). Safe here since this is a container.
 RUN pip3 install --no-cache-dir --break-system-packages \
-    torch --index-url https://download.pytorch.org/whl/cpu
+    torch --index-url https://download.pytorch.org/whl/cpu \
+    && pip3 install --no-cache-dir --break-system-packages gpytorch
 
 # Use pppm
 COPY .Rprofile /usr/local/lib/R/etc/Rprofile.site

--- a/cuda-bench/Dockerfile
+++ b/cuda-bench/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update \
 # --break-system-packages is needed because Ubuntu 24.04+ marks system Python as
 # externally managed (PEP 668). Safe here since this is a container.
 RUN pip3 install --no-cache-dir --break-system-packages \
-    torch --index-url https://download.pytorch.org/whl/cu124
+    torch --index-url https://download.pytorch.org/whl/cu124 \
+    && pip3 install --no-cache-dir --break-system-packages gpytorch
 
 # Use pppm
 COPY .Rprofile /usr/local/lib/R/etc/Rprofile.site


### PR DESCRIPTION
## Summary
- Adds `gpytorch` pip package to both `cpu-bench` and `cuda-bench` Dockerfiles
- Needed for the new GP benchmark in r-xla/benchmarks that compares anvil vs gpytorch

## Test plan
- [ ] Build cpu-bench image and verify `import gpytorch` works
- [ ] Build cuda-bench image and verify `import gpytorch` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)