### PR TITLE
docs: document running the CUDA image with NVIDIA Container Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ docker pull ghcr.io/r-xla/<image-name>:latest
 docker pull ghcr.io/r-xla/<image-name>:release
 ```
 
+## Running the CUDA Image
+
+The CUDA images require the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) to be installed on the host, which exposes the host's GPUs to the container. Follow the upstream installation instructions for your Linux distribution and configure the Docker runtime before running the image.
+
+On WSL2, install the NVIDIA GPU driver on the **Windows host** only (do not install a Linux NVIDIA driver inside WSL2), then install the NVIDIA Container Toolkit inside the WSL2 distro as above. See NVIDIA's [CUDA on WSL user guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html) for details. Docker Desktop users can instead enable WSL integration in its settings, which ships the toolkit.
+
+Once installed, start the container with `--gpus all` to make all GPUs available:
+
+```bash
+docker run --rm -it --gpus all sebffischer/anvil-cuda:latest R
+```
+
 ## Additional Dockerfiles
 
 These Dockerfiles are available for local builds but are not automatically built in CI.


### PR DESCRIPTION
Covers the toolkit install requirement, a `docker run --gpus all` example, and a short WSL2 note (host-side driver + Docker Desktop alternative).