### PR TITLE
Build anvl-cpu as multi-arch (amd64 + arm64)

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -20,4 +20,4 @@ options(
   )
 )
 
-.libPaths(sprintf("/root/R/x86_64-pc-linux-gnu-library/%s.%s", R.version$major, R.version$minor))
+.libPaths(sprintf("/root/R/%s-library/%s.%s", R.version$platform, R.version$major, R.version$minor))

--- a/.github/actions/docker-build-by-digest/action.yaml
+++ b/.github/actions/docker-build-by-digest/action.yaml
@@ -1,0 +1,89 @@
+name: 'Docker Build (Push by Digest)'
+description: 'Build a Docker image for one platform and push it by digest to Docker Hub and GHCR. Output the digest for later manifest assembly.'
+
+inputs:
+  image_name_dockerhub:
+    description: 'Docker Hub image (e.g., docker.io/sebffischer/anvl-cpu)'
+    required: true
+  image_name_ghcr:
+    description: 'GHCR image (e.g., ghcr.io/r-xla/anvl-cpu)'
+    required: true
+  dockerfile:
+    description: 'Path to the Dockerfile'
+    required: true
+  platform:
+    description: 'Target platform (e.g., linux/amd64)'
+    required: true
+  push:
+    description: 'Whether to push'
+    required: true
+    default: 'false'
+  dockerhub_username:
+    required: false
+  dockerhub_token:
+    required: false
+  ghcr_token:
+    required: false
+  anvl_ref:
+    description: 'Git ref for r-xla/anvl to install'
+    required: false
+    default: ''
+  no_cache:
+    required: false
+    default: 'false'
+  github_pat:
+    description: 'Token passed as a Docker build secret for private repo access'
+    required: false
+    default: ''
+
+outputs:
+  digest:
+    description: 'Image digest pushed by this build'
+    value: ${{ steps.build.outputs.digest }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      if: inputs.push == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: docker.io
+        username: ${{ inputs.dockerhub_username }}
+        password: ${{ inputs.dockerhub_token }}
+
+    - name: Log in to GitHub Container Registry
+      if: inputs.push == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ inputs.ghcr_token }}
+
+    - name: Compute platform pair
+      id: pair
+      shell: bash
+      run: |
+        platform="${{ inputs.platform }}"
+        echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        platforms: ${{ inputs.platform }}
+        build-args: |
+          BUILDKIT_INLINE_CACHE=1
+          CACHEBUST=${{ github.run_id }}
+          ANVL_REF=${{ inputs.anvl_ref }}
+        secrets: ${{ inputs.github_pat != '' && format('github_pat={0}', inputs.github_pat) || '' }}
+        no-cache: ${{ inputs.no_cache == 'true' }}
+        cache-from: ${{ inputs.no_cache != 'true' && format('type=registry,ref={0}:buildcache-{1}', inputs.image_name_dockerhub, steps.pair.outputs.pair) || '' }}
+        cache-to: ${{ inputs.push == 'true' && format('type=registry,ref={0}:buildcache-{1},image-manifest=true', inputs.image_name_dockerhub, steps.pair.outputs.pair) || '' }}
+        outputs: |
+          type=image,"name=${{ inputs.image_name_dockerhub }},${{ inputs.image_name_ghcr }}",push-by-digest=true,name-canonical=true,push=${{ inputs.push }}

--- a/.github/actions/docker-merge/action.yaml
+++ b/.github/actions/docker-merge/action.yaml
@@ -1,0 +1,66 @@
+name: 'Docker Merge Manifest'
+description: 'Combine per-platform digests into a multi-arch manifest list and publish under a tag in both Docker Hub and GHCR.'
+
+inputs:
+  image_name_dockerhub:
+    description: 'Docker Hub image (e.g., docker.io/sebffischer/anvl-cpu)'
+    required: true
+  image_name_ghcr:
+    description: 'GHCR image (e.g., ghcr.io/r-xla/anvl-cpu)'
+    required: true
+  tag:
+    description: 'Tag to publish (e.g., latest, release)'
+    required: true
+  digests_dir:
+    description: 'Directory containing per-platform digest files (filename = digest hex without sha256: prefix)'
+    required: true
+  dockerhub_username:
+    required: true
+  dockerhub_token:
+    required: true
+  ghcr_token:
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        registry: docker.io
+        username: ${{ inputs.dockerhub_username }}
+        password: ${{ inputs.dockerhub_token }}
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ inputs.ghcr_token }}
+
+    - name: Create manifest list (Docker Hub)
+      shell: bash
+      working-directory: ${{ inputs.digests_dir }}
+      run: |
+        docker buildx imagetools create \
+          -t "${{ inputs.image_name_dockerhub }}:${{ inputs.tag }}" \
+          $(printf '${{ inputs.image_name_dockerhub }}@sha256:%s ' *)
+
+    - name: Create manifest list (GHCR)
+      shell: bash
+      working-directory: ${{ inputs.digests_dir }}
+      run: |
+        docker buildx imagetools create \
+          -t "${{ inputs.image_name_ghcr }}:${{ inputs.tag }}" \
+          $(printf '${{ inputs.image_name_ghcr }}@sha256:%s ' *)
+
+    - name: Inspect (Docker Hub)
+      shell: bash
+      run: docker buildx imagetools inspect "${{ inputs.image_name_dockerhub }}:${{ inputs.tag }}"
+
+    - name: Inspect (GHCR)
+      shell: bash
+      run: docker buildx imagetools inspect "${{ inputs.image_name_ghcr }}:${{ inputs.tag }}"

--- a/.github/workflows/cpu.yaml
+++ b/.github/workflows/cpu.yaml
@@ -12,6 +12,10 @@ on:
     branches:
       - main
 
+env:
+  IMAGE_DOCKERHUB: docker.io/sebffischer/anvl-cpu
+  IMAGE_GHCR: ghcr.io/r-xla/anvl-cpu
+
 jobs:
   resolve-anvl-release:
     runs-on: ubuntu-latest
@@ -45,44 +49,150 @@ jobs:
           fi
 
   build-latest:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/docker-build
+      - id: build
+        uses: ./.github/actions/docker-build-by-digest
         with:
-          image_name: sebffischer/anvl-cpu
+          image_name_dockerhub: ${{ env.IMAGE_DOCKERHUB }}
+          image_name_ghcr: ${{ env.IMAGE_GHCR }}
           dockerfile: ./cpu/Dockerfile
+          platform: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           ghcr_token: ${{ secrets.GITHUB_TOKEN }}
           github_pat: ${{ secrets.GITHUB_TOKEN }}
-          extra_tags: |
-            docker.io/sebffischer/anvl-cpu:latest
-            ghcr.io/${{ github.repository_owner }}/anvl-cpu:latest
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Compute platform pair
+        if: github.event_name != 'pull_request'
+        id: pair
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-latest-${{ steps.pair.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
-  build-release:
-    needs: resolve-anvl-release
-    if: needs.resolve-anvl-release.outputs.changed == 'true'
+  merge-latest:
+    needs: build-latest
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/docker-build
+      - name: Download digests
+        uses: actions/download-artifact@v4
         with:
-          image_name: sebffischer/anvl-cpu
+          path: /tmp/digests
+          pattern: digests-latest-*
+          merge-multiple: true
+      - uses: ./.github/actions/docker-merge
+        with:
+          image_name_dockerhub: ${{ env.IMAGE_DOCKERHUB }}
+          image_name_ghcr: ${{ env.IMAGE_GHCR }}
+          tag: latest
+          digests_dir: /tmp/digests
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-release:
+    needs: resolve-anvl-release
+    if: needs.resolve-anvl-release.outputs.changed == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - id: build
+        uses: ./.github/actions/docker-build-by-digest
+        with:
+          image_name_dockerhub: ${{ env.IMAGE_DOCKERHUB }}
+          image_name_ghcr: ${{ env.IMAGE_GHCR }}
           dockerfile: ./cpu/Dockerfile
+          platform: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           ghcr_token: ${{ secrets.GITHUB_TOKEN }}
           github_pat: ${{ secrets.GITHUB_TOKEN }}
           anvl_ref: ${{ needs.resolve-anvl-release.outputs.tag }}
-          extra_tags: |
-            docker.io/sebffischer/anvl-cpu:release
-            ghcr.io/${{ github.repository_owner }}/anvl-cpu:release
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Compute platform pair
+        if: github.event_name != 'pull_request'
+        id: pair
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-release-${{ steps.pair.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-release:
+    needs: build-release
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-release-*
+          merge-multiple: true
+      - uses: ./.github/actions/docker-merge
+        with:
+          image_name_dockerhub: ${{ env.IMAGE_DOCKERHUB }}
+          image_name_ghcr: ${{ env.IMAGE_GHCR }}
+          tag: release
+          digests_dir: /tmp/digests
+          dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Build `anvl-cpu` for both `linux/amd64` and `linux/arm64`, producing a real multi-arch manifest list at `:latest` and `:release`.
- Use **native** GitHub-hosted runners (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) — no QEMU.
- Each platform leg pushes **by digest** to both Docker Hub and GHCR; a separate `merge` job assembles the manifest list under each tag.
- CUDA workflow is unchanged; the original `docker-build` composite action keeps its single-arch behavior so `cuda.yaml` is unaffected.
- Drop the hardcoded `x86_64-pc-linux-gnu` libPath in `.Rprofile`; use `R.version$platform` so it's correct on arm64.

### Why

The current image is published as a manifest list with only an amd64 entry. On Apple Silicon, `docker pull ghcr.io/r-xla/anvl-cpu:latest` fails with `no matching manifest for linux/arm64/v8`, which breaks `devcontainer up` since the CLI's pre-pull step does not honor `--platform=linux/amd64` from `build.options`. Publishing a real arm64 entry fixes that and lets the dev container run natively on M-series Macs.

### Notes for reviewers

- arm64 R packages will fall back to source compilation (Posit PPM doesn't ship arm64 Linux binaries for Noble). First daily build will be slower; subsequent builds use per-platform `buildcache-linux-arm64` cache.
- New composite actions:
  - `.github/actions/docker-build-by-digest/`
  - `.github/actions/docker-merge/`

## Test plan

- [ ] Open the PR and let the workflow run on `pull_request` (push disabled). Both `build-latest` legs should complete on their respective runners; `merge-latest` is skipped on PR.
- [ ] After merge to main, verify `docker buildx imagetools inspect ghcr.io/r-xla/anvl-cpu:latest` lists both `linux/amd64` and `linux/arm64`.
- [ ] On an Apple Silicon host, `docker pull ghcr.io/r-xla/anvl-cpu:latest` (no `--platform`) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)