### PR TITLE
Set PJRT_INSTALL=1 for build-time plugin downloads

### DIFF
--- a/cpu/Dockerfile
+++ b/cpu/Dockerfile
@@ -32,7 +32,8 @@ RUN --mount=type=secret,id=github_pat \
     ANVL_REF="${ANVL_REF:-HEAD}" \
     R -q -e "remotes::install_github('r-xla/anvl', ref = Sys.getenv('ANVL_REF'), force = TRUE)"
 
-# Trigger PJRT plugin download
-RUN R -q -e "anvl::nv_array(1, device = 'cpu')"
+# Trigger PJRT plugin download. PJRT_INSTALL=1 allows the download in this
+# non-interactive build (pjrt otherwise only downloads when asked interactively).
+RUN PJRT_INSTALL=1 R -q -e "anvl::nv_array(1, device = 'cpu')"
 
 CMD ["bash"]

--- a/cuda/Dockerfile
+++ b/cuda/Dockerfile
@@ -18,7 +18,9 @@ RUN --mount=type=secret,id=github_pat \
     R -q -e "remotes::install_github('r-xla/anvl', ref = Sys.getenv('ANVL_REF'), force = TRUE)"
 
 # Download PJRT plugins
-# Can't use nv_array() here because it fails if no GPU is available
-RUN R -q -e "options(timeout = 600); pjrt:::plugin_path('cpu'); pjrt:::plugin_path('cuda')"
+# Can't use nv_array() here because it fails if no GPU is available.
+# PJRT_INSTALL=1 allows the download in this non-interactive build (pjrt
+# otherwise only downloads when asked interactively).
+RUN PJRT_INSTALL=1 R -q -e "options(timeout = 600); pjrt:::plugin_path('cpu'); pjrt:::plugin_path('cuda')"
 
 CMD ["bash"]


### PR DESCRIPTION
pjrt no longer downloads its plugin automatically in non-interactive sessions — it now errors unless `PJRT_INSTALL=1` is set (matching torch's `TORCH_INSTALL` behaviour; see r-xla/pjrt#202).

The `cpu` and `cuda` image builds trigger the plugin download in a non-interactive `R -q -e` step, so they need `PJRT_INSTALL=1`:

- `cpu/Dockerfile`: `RUN PJRT_INSTALL=1 R -q -e "anvl::nv_array(1, device = 'cpu')"`
- `cuda/Dockerfile`: `RUN PJRT_INSTALL=1 R -q -e "...; pjrt:::plugin_path('cpu'); pjrt:::plugin_path('cuda')"`

Scoped to the individual `RUN` commands (not a global `ENV`) so runtime behaviour is unchanged. Harmless with older pjrt versions, where non-interactive downloads already proceeded.

The `cpu-bench` / `cuda-bench` images build `FROM` the already-baked `anvl-cpu` / `anvl-cuda` images and don't trigger a pjrt download, so they need no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)